### PR TITLE
Decoupling from the fh-wfm-sync module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 npm-debug.log
-.idea
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,21 +1,23 @@
 module.exports = function(grunt) {
   'use strict';
+
+  require('load-grunt-tasks')(grunt);
   grunt.initConfig({
     eslint: {
       src: ["lib/**/*.js"]
     },
     mochaTest: {
       test: {
+        src: ['lib/**/*-spec.js'],
         options: {
+          reporter: 'Spec',
+          logErrors: true,
+          timeout: 10000,
           run: true
-        },
-        src: ['lib/**/*spec.js']
+        }
       }
     }
   });
-  grunt.loadNpmTasks("grunt-eslint");
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.registerTask('mocha', ['mochaTest']);
-  grunt.registerTask('unit',['eslint', 'mocha']);
-  grunt.registerTask('default', ['unit']);
+  grunt.registerTask('test', ['eslint', 'mochaTest']);
+  grunt.registerTask('default', ['test']);
 };

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ This module contains a workflow model representation and its related services :
 
 ## Client-side usage
 
-### Client-side usage (via broswerify)
-
-#### Setup
+### Setup
 This module is packaged in a CommonJS format, exporting the name of the Angular namespace.  The module can be included in an angular.js as follows:
 
 ```javascript
@@ -19,9 +17,9 @@ angular.module('app', [
 ])
 ```
 
-#### Integration
+### Integration
 
-##### Angular controller
+#### Angular controller
 A sync manager must first be initialized using the `workflowSync.createManager()`.  This can be placed, for instance, in the `resolve` config of a `ui-router` controlled application.
 
 ```javascript
@@ -34,7 +32,7 @@ resolve: {
 For a more complete example, please check the [demo portal app](https://github.com/feedhenry-staff/wfm-portal/blob/master/src/app/main.js).
 
 
-##### `workflowSync` API
+#### `workflowSync` API
 These workflowSync API methods all return Promises:
 
 | workflowSync method | Description |
@@ -44,7 +42,7 @@ These workflowSync API methods all return Promises:
 | `workflowSync.manager.read(workflowId)` | read a workflow |
 | `workflowSync.manager.update(workflow)` | update a workflow |
 
-#### workflow directives
+### workflow directives
 
 | Name | Attributes |
 | ---- | ----------- |
@@ -54,6 +52,149 @@ These workflowSync API methods all return Promises:
 | workflow-form | value |
 | workflow-step-form | workflow, step, forms |
 | workflow-step-detail | step |
+
+### Topic Subscriptions
+
+#### wfm:workflows:create
+
+##### Description
+
+Creating a new Workflow
+
+##### Example
+
+
+```javascript
+var parameters = {
+  workflowToCreate: {
+    //A Valid JSON Object
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:workflows:create", parameters);
+```
+
+#### wfm:workflows:read
+
+##### Description
+
+Read a single Workflow
+
+##### Example
+
+
+```javascript
+var parameters = {
+  id: "workflowId",
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:workflows:read", parameters);
+```
+
+#### wfm:workflows:update
+
+##### Description
+
+Update a single Workflow
+
+##### Example
+
+
+```javascript
+var parameters = {
+  workflowToUpdate: {
+    ...
+    id: "workflowId"
+    ...
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:workflows:update", parameters);
+```
+
+
+#### wfm:workflows:remove
+
+##### Description
+
+Remove a single Workflow
+
+##### Example
+
+
+```javascript
+var parameters = {
+  id: "workflowId",
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:workflows:remove", parameters);
+```
+
+
+#### wfm:workflows:list
+
+##### Description
+
+List All Workflows
+
+##### Example
+
+
+```javascript
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:workflows:list", parameters);
+```
+
+
+### Published Topics
+
+The following topics are published by this module. Developers are free to implement these topics subscribers, or use a module that already has these subscribers implement (E.g. the [raincatcher-sync](https://github.com/feedhenry-raincatcher/raincatcher-sync) module).
+
+
+| Topic         | Description           |
+| ------------- |:-------------:| 
+| wfm:sync:workflows:create              |   Create a new item in the sync `workflows` collection |
+| wfm:sync:workflows:update              |   Update an existing item in the sync `workflows` collection |
+| wfm:sync:workflows:list              |   List all items in the sync `workflows` collection |
+| wfm:sync:workflows:remove              |   Remove an existing item from the sync `workflows` collection |
+| wfm:sync:workflows:read              |   Read a single item from the sync `workflows` collection |
+| wfm:sync:workflows:start              |   Start the sync process for sync `workflows` collection |
+| wfm:sync:workflows:stop              |   Stop the sync process for sync `workflows` collection |
+| wfm:sync:workflows:force_sync        |   Force a sync cycle from client to cloud for sync `workflows` collection |
+
+
+### Topic Subscriptions
+
+| Topic         | Description           |
+| ------------- |:-------------:| 
+| done:wfm:sync:workflows:create        |   A workflow was created in the `workflows` dataset |
+| error:wfm:sync:workflows:create        |   An error occurred when creating an item in the `workflows` dataset. |
+| done:wfm:sync:workflows:update        |   A workflow was updated in the `workflows` dataset |
+| error:wfm:sync:workflows:update        |   An error occurred when updating an item in the `workflows` dataset. |
+| done:wfm:sync:workflows:list        |   A list of the items in the `workflows` dataset completed |
+| error:wfm:sync:workflows:list        |   An error occurred when listing items in the `workflows` dataset. |
+| done:wfm:sync:workflows:remove        |   A workflow was removed from the `workflows` dataset |
+| error:wfm:sync:workflows:remove        |   An error occurred when removing an item in the `workflows` dataset. |
+| done:wfm:sync:workflows:read        |   A item was read correctly from the `workflows` dataset |
+| error:wfm:sync:workflows:read        |   An error occurred when reading an item in the `workflows` dataset. |
+| done:wfm:sync:workflows:start        |   The sync process started for the `workflows` dataset. |
+| error:wfm:sync:workflows:start        |   An error occurred when starting the `workflows` dataset. |
+| done:wfm:sync:workflows:stop        |   The sync process stopped for the `workflows` dataset. |
+| error:wfm:sync:workflows:stop        |   An error occurred when stopping the `workflows` dataset sync process. |
+| done:wfm:sync:workflows:force_sync        |  A force sync process completed for the `workflows` dataset. |
+| error:wfm:sync:workflows:force_sync        |   An error occurred when forcing the sync process for the `workflows` dataset. |
 
 
 ## Usage in an express backend

--- a/lib/angular/service.js
+++ b/lib/angular/service.js
@@ -4,6 +4,9 @@ var config = require('../config')
   , _ = require('lodash')
   ;
 
+var workflowClient = require('../client/workflow-client');
+var workflowMediatorSubscribers = require('../client/mediator-subscribers');
+
 module.exports = 'wfm.workflow.sync';
 
 function wrapManager($q, $timeout, manager) {
@@ -22,69 +25,27 @@ function wrapManager($q, $timeout, manager) {
   return wrappedManager;
 }
 
-angular.module('wfm.workflow.sync', [require('fh-wfm-sync')])
-.factory('workflowSync', function($q, $timeout, syncService) {
-  syncService.init(config.syncOptions);
+angular.module('wfm.workflow.sync', [])
+.factory('workflowSync', function($q, $timeout, mediator) {
   var workflowSync = {};
   workflowSync.createManager = function(queryParams) {
     if (workflowSync.manager) {
       return $q.when(workflowSync.manager);
     } else {
-      return workflowSync.managerPromise = syncService.manage(config.datasetId, null, queryParams)
-      .then(function(manager) {
-        workflowSync.manager = wrapManager($q, $timeout, manager);
-        console.log('Sync is managing dataset:', config.datasetId, 'with filter: ', queryParams);
-        // TODO: we should refactor these utilities functions somewhere else probably
-        workflowSync.manager.stepReview = function(steps, result) {
-          var stepIndex = -1;
-          var complete;
-          if (result && result.stepResults && result.stepResults.length !== 0) {
-            complete = true;
-            for (var i=0; i < steps.length; i++) {
-              var step = steps[i];
-              var stepResult = result.stepResults[step.code];
-              if (stepResult && (stepResult.status === 'complete' || stepResult.status === 'pending')) {
-                stepIndex = i;
-                if (stepResult.status === 'pending') {
-                  complete = false;
-                }
-              } else {
-                break;
-              }
-            }
-          }
-          return {
-            nextStepIndex: stepIndex,
-            complete: complete // false is any steps are "pending"
-          };
-        };
+      workflowSync.manager = wrapManager($q, $timeout, workflowClient(mediator));
 
-        workflowSync.manager.nextStepIndex = function(steps, result) {
-          return this.stepReview(steps, result).nextStepIndex;
-        };
-
-        workflowSync.manager.checkStatus = function(workorder, workflow, result) {
-          var status;
-          var stepReview = this.stepReview(workflow.steps, result);
-          if (stepReview.nextStepIndex >= workflow.steps.length - 1 && stepReview.complete) {
-            status = 'Complete';
-          } else if (!workorder.assignee) {
-            status = 'Unassigned';
-          } else if (stepReview.nextStepIndex < 0) {
-            status = 'New';
-          } else {
-            status = 'In Progress';
-          }
-          return status;
-        };
-        return workflowSync.manager;
-      });
+      //Initialising subscribers for this module.
+      workflowMediatorSubscribers.init(mediator);
+      console.log('Sync is managing dataset:', config.datasetId, 'with filter: ', queryParams);
+      return workflowSync.manager;
     }
   };
   workflowSync.removeManager = function() {
     if (workflowSync.manager) {
       return workflowSync.manager.safeStop()
       .then(function() {
+        //Removing any workflow subscribers
+        workflowMediatorSubscribers.tearDown();
         delete workflowSync.manager;
       });
     }

--- a/lib/client/mediator-subscribers/create-spec.js
+++ b/lib/client/mediator-subscribers/create-spec.js
@@ -1,0 +1,96 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Workflow Create Mediator Topic", function() {
+
+  var mockWorkflowToCreate = {
+    name: "This is a mock Work Order"
+  };
+
+  var expectedCreatedWorkflow =  _.extend({_localuid: "createdWorkflowLocalId"}, mockWorkflowToCreate);
+
+  var topicUid = 'testtopicuid1';
+
+  var createTopic = "wfm:workflows:create";
+  var doneCreateTopic = "done:wfm:workflows:create:testtopicuid1";
+  var errorCreateTopic = "error:wfm:workflows:create:testtopicuid1";
+
+  var syncCreateTopic = "wfm:sync:workflows:create";
+  var doneSyncCreateTopic = "done:wfm:sync:workflows:create";
+  var errorSyncCreateTopic = "error:wfm:sync:workflows:create";
+
+  var workflowSubscribers = new MediatorTopicUtility(mediator);
+  workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    workflowSubscribers.on(CONSTANTS.TOPICS.CREATE, require('./create')(workflowSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    workflowSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to create a workflow', function() {
+    this.subscribers[syncCreateTopic] = mediator.subscribe(syncCreateTopic, function(parameters) {
+      expect(parameters.itemToCreate).to.deep.equal(mockWorkflowToCreate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(doneSyncCreateTopic + ":" + parameters.topicUid, expectedCreatedWorkflow);
+    });
+
+    var donePromise = mediator.promise(doneCreateTopic);
+
+    mediator.publish(createTopic, {
+      workflowToCreate: mockWorkflowToCreate,
+      topicUid: topicUid
+    });
+
+    return donePromise.then(function(createdWorkflow) {
+      expect(createdWorkflow).to.deep.equal(expectedCreatedWorkflow);
+    });
+  });
+
+  it('should publish an error if there is no object to update', function() {
+    var errorPromise = mediator.promise(errorCreateTopic);
+
+    mediator.publish(createTopic, {
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncCreateTopic] = mediator.subscribe(syncCreateTopic, function(parameters) {
+      expect(parameters.itemToCreate).to.deep.equal(mockWorkflowToCreate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(errorSyncCreateTopic + ":" + parameters.topicUid, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorCreateTopic);
+
+    mediator.publish(createTopic, {
+      workflowToCreate: mockWorkflowToCreate,
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/create.js
+++ b/lib/client/mediator-subscribers/create.js
@@ -1,0 +1,42 @@
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var workflowClient = require('../workflow-client');
+
+
+/**
+ * Initialising a subscriber for creating a workflow.
+ *
+ * @param {object} workflowEntityTopics
+ *
+ */
+module.exports = function createWorkflowSubscriber(workflowEntityTopics) {
+
+  /**
+   *
+   * Handling the creation of a workflow
+   *
+   * @param {object} parameters
+   * @param {object} parameters.workflowToCreate   - The workflow item to create
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleCreateWorkflowTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var workflowCreateErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var workflowToCreate = parameters.workflowToCreate;
+
+    //If no workflow is passed, can't create one
+    if (!_.isPlainObject(workflowToCreate)) {
+      return self.mediator.publish(workflowCreateErrorTopic, new Error("Invalid Data To Create A Workflow."));
+    }
+
+    workflowClient(self.mediator).manager.create(workflowToCreate)
+    .then(function(createdWorkflow) {
+      self.mediator.publish(workflowEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, parameters.topicUid), createdWorkflow);
+    }).catch(function(error) {
+      self.mediator.publish(workflowCreateErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -1,0 +1,45 @@
+var _ = require('lodash');
+var topicHandlers = {
+  create: require('./create'),
+  update: require('./update'),
+  remove: require('./remove'),
+  list: require('./list'),
+  read: require('./read')
+};
+var CONSTANTS = require('../../constants');
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+var workflowSubscribers;
+
+module.exports = {
+  /**
+   * Initialisation of all the topics that this module is interested in.
+   * @param mediator
+   * @returns {Topics|exports|module.exports|*}
+   */
+  init: function(mediator) {
+
+    //If there is already a set of subscribers set up, then don't subscribe again.
+    if (workflowSubscribers) {
+      return workflowSubscribers;
+    }
+
+    workflowSubscribers = new MediatorTopicUtility(mediator);
+    workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+    //Setting up subscribers to the workflow topics.
+    _.each(CONSTANTS.TOPICS, function(topicName) {
+      if (topicHandlers[topicName]) {
+        workflowSubscribers.on(topicName, topicHandlers[topicName](workflowSubscribers));
+      }
+    });
+
+    return workflowSubscribers;
+  },
+  tearDown: function() {
+    if (workflowSubscribers) {
+      workflowSubscribers.unsubscribeAll();
+    }
+  }
+};

--- a/lib/client/mediator-subscribers/list-spec.js
+++ b/lib/client/mediator-subscribers/list-spec.js
@@ -1,0 +1,70 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Workflow List Mediator Topic", function() {
+
+  var mockWorkflow = {
+    id: "workflowid",
+    name: "This is a mock Work Order"
+  };
+
+  var workflows = [_.clone(mockWorkflow), _.clone(mockWorkflow)];
+
+  var listTopic = "wfm:workflows:list";
+  var doneListTopic = "done:wfm:workflows:list";
+  var errorListTopic = "error:wfm:workflows:list";
+
+  var syncListTopic = "wfm:sync:workflows:list";
+  var doneSyncListTopic = "done:wfm:sync:workflows:list";
+  var errorSyncListTopic = "error:wfm:sync:workflows:list";
+
+  var workflowSubscribers = new MediatorTopicUtility(mediator);
+  workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    workflowSubscribers.on(CONSTANTS.TOPICS.LIST, require('./list')(workflowSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    workflowSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to list workflows', function() {
+    this.subscribers[syncListTopic] = mediator.subscribe(syncListTopic, function() {
+      mediator.publish(doneSyncListTopic, workflows);
+    });
+
+    var donePromise = mediator.promise(doneListTopic);
+
+    mediator.publish(listTopic);
+
+    return donePromise.then(function(arrayOfWorkflows) {
+      expect(arrayOfWorkflows).to.deep.equal(workflows);
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncListTopic] = mediator.subscribe(syncListTopic, function() {
+      mediator.publish(errorSyncListTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorListTopic);
+
+    mediator.publish(listTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -1,0 +1,34 @@
+var CONSTANTS = require('../../constants');
+var workflowClient = require('../workflow-client');
+
+/**
+ * Initialsing a subscriber for Listing workflows.
+ *
+ * @param {object} workflowEntityTopics
+ *
+ */
+module.exports = function listWorkflowSubscriber(workflowEntityTopics) {
+
+  /**
+   *
+   * Handling the listing of workflows
+   *
+   * @param {object} parameters
+   * @param {string/number} parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleListWorkflowsTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var workflowListErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var workflowListDoneTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    workflowClient(self.mediator).manager.list()
+    .then(function(arrayOfWorkflows) {
+      self.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
+    }).catch(function(error) {
+      self.mediator.publish(workflowListErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/read-spec.js
+++ b/lib/client/mediator-subscribers/read-spec.js
@@ -1,0 +1,86 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Workflow Read Mediator Topic", function() {
+
+  var mockWorkflow = {
+    id: "workflowid",
+    name: "This is a mock Work Order"
+  };
+
+  var readTopic = "wfm:workflows:read";
+  var doneReadTopic = "done:wfm:workflows:read:workflowid";
+  var errorReadTopic = "error:wfm:workflows:read";
+
+  var syncReadTopic = "wfm:sync:workflows:read";
+  var doneSyncReadTopic = "done:wfm:sync:workflows:read:workflowid";
+  var errorSyncReadTopic = "error:wfm:sync:workflows:read:workflowid";
+
+  var workflowSubscribers = new MediatorTopicUtility(mediator);
+  workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+  var readSubscribers = require('./read')(workflowSubscribers);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    workflowSubscribers.on(CONSTANTS.TOPICS.READ, readSubscribers);
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    workflowSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to read workflow', function() {
+    this.subscribers[syncReadTopic] = mediator.subscribe(syncReadTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockWorkflow.id);
+
+      mediator.publish(doneSyncReadTopic, mockWorkflow);
+    });
+
+    var donePromise = mediator.promise(doneReadTopic);
+
+    mediator.publish(readTopic, {id: mockWorkflow.id, topicUid: mockWorkflow.id});
+
+    return donePromise.then(function(readWorkflow) {
+      expect(readWorkflow).to.deep.equal(mockWorkflow);
+    });
+  });
+
+  it('should publish an error if there is no ID to read', function() {
+    var errorPromise = mediator.promise(errorReadTopic);
+
+    mediator.publish(readTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Expected An ID");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncReadTopic] = mediator.subscribe(syncReadTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockWorkflow.id);
+
+      mediator.publish(errorSyncReadTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorReadTopic + ":" + mockWorkflow.id);
+
+    mediator.publish(readTopic, {id: mockWorkflow.id, topicUid: mockWorkflow.id});
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/read.js
+++ b/lib/client/mediator-subscribers/read.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var workflowClient = require('../workflow-client');
+
+/**
+ * Initialsing a subscriber for reading workflows.
+ *
+ * @param {object} workflowEntityTopics
+ *
+ */
+module.exports = function readWorkflowSubscriber(workflowEntityTopics) {
+
+
+  /**
+   *
+   * Handling the reading of a single workflow
+   *
+   * @param {object} parameters
+   * @param {string} parameters.id - The ID of the workflow to read.
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleReadWorkflowsTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    var workflowReadErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var workflowReadDoneTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    //If there is no ID, then we can't read the workflow.
+    if (!parameters.id) {
+      return self.mediator.publish(workflowReadErrorTopic, new Error("Expected An ID When Reading A Workflow"));
+    }
+
+    workflowClient(self.mediator).manager.read(parameters.id)
+    .then(function(workflow) {
+      self.mediator.publish(workflowReadDoneTopic, workflow);
+    }).catch(function(error) {
+      self.mediator.publish(workflowReadErrorTopic, error);
+    });
+  };
+
+};

--- a/lib/client/mediator-subscribers/remove-spec.js
+++ b/lib/client/mediator-subscribers/remove-spec.js
@@ -1,0 +1,82 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Workflow Remove Mediator Topic", function() {
+
+  var mockWorkflow = {
+    id: "workflowid",
+    name: "This is a mock Work Order"
+  };
+
+  var removeTopic = "wfm:workflows:remove";
+  var doneRemoveTopic = "done:wfm:workflows:remove:workflowid";
+  var errorRemoveTopic = "error:wfm:workflows:remove";
+
+  var syncRemoveTopic = "wfm:sync:workflows:remove";
+  var doneSyncRemoveTopic = "done:wfm:sync:workflows:remove:workflowid";
+  var errorSyncRemoveTopic = "error:wfm:sync:workflows:remove:workflowid";
+
+  var workflowSubscribers = new MediatorTopicUtility(mediator);
+  workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    workflowSubscribers.on(CONSTANTS.TOPICS.REMOVE, require('./remove')(workflowSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    workflowSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to remove a workflow', function() {
+    this.subscribers[syncRemoveTopic] = mediator.subscribe(syncRemoveTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockWorkflow.id);
+
+      mediator.publish(doneSyncRemoveTopic, mockWorkflow);
+    });
+
+    var donePromise = mediator.promise(doneRemoveTopic);
+
+    mediator.publish(removeTopic, {id: mockWorkflow.id, topicUid: mockWorkflow.id});
+
+    return donePromise;
+  });
+
+  it('should publish an error if there is no ID to remove', function() {
+    var errorPromise = mediator.promise(errorRemoveTopic);
+
+    mediator.publish(removeTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Expected An ID");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncRemoveTopic] = mediator.subscribe(syncRemoveTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockWorkflow.id);
+
+      mediator.publish(errorSyncRemoveTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorRemoveTopic + ":" + mockWorkflow.id);
+
+    mediator.publish(removeTopic, {id: mockWorkflow.id, topicUid: mockWorkflow.id});
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/remove.js
+++ b/lib/client/mediator-subscribers/remove.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var workflowClient = require('../workflow-client');
+
+/**
+ * Initialsing a subscriber for removing workflows.
+ *
+ * @param {object} workflowEntityTopics
+ *
+ */
+module.exports = function removeWorkflowSubscriber(workflowEntityTopics) {
+
+
+  /**
+   *
+   * Handling the removal of a single workflow
+   *
+   * @param {object} parameters
+   * @param {string} parameters.id - The ID of the workflow to remove.
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleRemoveWorkflow(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var workflowRemoveErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var workflowRemoveDoneTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    //If there is no ID, then we can't read the workflow.
+    if (!parameters.id) {
+      return self.mediator.publish(workflowRemoveErrorTopic, new Error("Expected An ID When Removing A Workflow"));
+    }
+
+    workflowClient(self.mediator).manager.delete({
+      id: parameters.id
+    })
+    .then(function() {
+      self.mediator.publish(workflowRemoveDoneTopic);
+    }).catch(function(error) {
+      self.mediator.publish(workflowRemoveErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/update-spec.js
+++ b/lib/client/mediator-subscribers/update-spec.js
@@ -1,0 +1,111 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+
+describe("Workflow Update Mediator Topic", function() {
+
+  var mockWorkflowToUpdate = {
+    id: "workflowidtoupdate",
+    name: "This is a mock Work Order"
+  };
+
+  var expectedUpdatedWorkflow =  _.defaults({name: "Updated Workflow"}, mockWorkflowToUpdate);
+
+  var topicUid = 'testtopicuid1';
+
+  var updateTopic = "wfm:workflows:update";
+  var doneUpdateTopic = "done:wfm:workflows:update:testtopicuid1";
+  var errorUpdateTopic = "error:wfm:workflows:update:testtopicuid1";
+
+  var syncUpdateTopic = "wfm:sync:workflows:update";
+  var doneSyncUpdateTopic = "done:wfm:sync:workflows:update";
+  var errorSyncUpdateTopic = "error:wfm:sync:workflows:update";
+
+  var workflowSubscribers = new MediatorTopicUtility(mediator);
+  workflowSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    workflowSubscribers.on(CONSTANTS.TOPICS.UPDATE, require('./update')(workflowSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    workflowSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to update a workflow', function() {
+    this.subscribers[syncUpdateTopic] = mediator.subscribe(syncUpdateTopic, function(parameters) {
+      expect(parameters.itemToUpdate).to.deep.equal(mockWorkflowToUpdate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(doneSyncUpdateTopic + ":" + parameters.topicUid, expectedUpdatedWorkflow);
+    });
+
+    var donePromise = mediator.promise(doneUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      workflowToUpdate: mockWorkflowToUpdate,
+      topicUid: topicUid
+    });
+
+    return donePromise.then(function(updatedWorkflow) {
+      expect(updatedWorkflow).to.deep.equal(expectedUpdatedWorkflow);
+    });
+  });
+
+  it('should publish an error if there is no object to update', function() {
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should publish an error if there is no workflow id', function() {
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      workflowToUpdate: {},
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+
+    this.subscribers[syncUpdateTopic] = mediator.subscribe(syncUpdateTopic, function(parameters) {
+      expect(parameters.itemToUpdate).to.deep.equal(mockWorkflowToUpdate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(errorSyncUpdateTopic + ":" + parameters.topicUid, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      workflowToUpdate: mockWorkflowToUpdate,
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var _ = require('lodash');
+var workflowClient = require('../workflow-client');
+
+/**
+ * Initialsing a subscriber for updating a workflow.
+ *
+ * @param {object} workflowEntityTopics
+ *
+ */
+module.exports = function updateWorkflowSubscriber(workflowEntityTopics) {
+
+  /**
+   *
+   * Handling the update of a workflow
+   *
+   * @param {object} parameters
+   * @param {object} parameters.workflowToUpdate   - The workflow item to update
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleUpdateTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var workflowUpdateErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var workflowUpdateDoneTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    var workflowToUpdate = parameters.workflowToUpdate;
+
+    //If no workflow is passed, can't update one. Also require the ID of the workorde to update it.
+    if (!_.isPlainObject(workflowToUpdate) || !workflowToUpdate.id) {
+      return self.mediator.publish(workflowUpdateErrorTopic, new Error("Invalid Data To Update A Workflow."));
+    }
+
+    workflowClient(self.mediator).manager.update(workflowToUpdate)
+    .then(function(updatedWorkflow) {
+      self.mediator.publish(workflowUpdateDoneTopic, updatedWorkflow);
+    }).catch(function(error) {
+      self.mediator.publish(workflowUpdateErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/workflow-client/index.js
+++ b/lib/client/workflow-client/index.js
@@ -1,0 +1,299 @@
+var q = require('q');
+var _ = require('lodash');
+var shortid = require('shortid');
+var CONSTANTS = require('../../constants');
+var config = require('../../config');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var mediator, manager, workflowSyncSubscribers;
+
+/**
+ *
+ * Getting Promises for done and error topics.
+ *
+ * @param doneTopicPromise  - A promise for the done topic.
+ * @param errorTopicPromise - A promise for the error topic.
+ * @returns {*}
+ */
+function getTopicPromises(doneTopicPromise, errorTopicPromise) {
+  var deferred = q.defer();
+
+  doneTopicPromise.then(function(createdWorkflow) {
+    deferred.resolve(createdWorkflow);
+  });
+
+  errorTopicPromise.then(function(error) {
+    deferred.reject(error);
+  });
+
+  return deferred.promise;
+}
+
+
+/**
+ *
+ * Creating a new workflow.
+ *
+ * @param {object} workflowToCreate - The Workflow to create.
+ */
+function create(workflowToCreate) {
+
+  //Creating a unique channel to get the response
+  var topicUid = shortid.generate();
+
+  var topicParams = {topicUid: topicUid, itemToCreate: workflowToCreate};
+
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, topicUid));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, topicUid));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ *
+ * Updating an existing workflow.
+ *
+ * @param {object} workflowToUpdate - The workflow to update
+ * @param {string} workflowToUpdate.id - The ID of the workflow to update
+ */
+function update(workflowToUpdate) {
+  var topicParams = {topicUid: workflowToUpdate.id, itemToUpdate: workflowToUpdate};
+
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, topicParams.topicUid));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, topicParams.topicUid));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), topicParams);
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/***
+ *
+ * Reading a single workflow.
+ *
+ * @param {string} workflowId - The ID of the workflow to read
+ */
+function read(workflowId) {
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, workflowId));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, workflowId));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: workflowId, topicUid: workflowId});
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Listing All Workflows
+ */
+function list() {
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ *
+ * Removing a workororder using the sync topics
+ *
+ * @param {object} workflowToRemove
+ * @param {string} workflowToRemove.id - The ID of the workoroder to remove
+ */
+function remove(workflowToRemove) {
+
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.DONE_PREFIX, workflowToRemove.id));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.ERROR_PREFIX, workflowToRemove.id));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE),  {id: workflowToRemove.id, topicUid: workflowToRemove.id});
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Starting the synchronisation process for workflows.
+ */
+function start() {
+
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.START));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Stopping the synchronisation process for workflows.
+ */
+function stop() {
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Forcing the workflows to sync to the remote store.
+ */
+function forceSync() {
+  var donePromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Safe stop forces a synchronisation to the remote server and then stops the synchronisation process.
+ * @returns {Promise}
+ */
+function safeStop() {
+  return forceSync().then(stop);
+}
+
+
+/**
+ * Waiting for the synchronisation process to complete to the remote cluster.
+ */
+function waitForSync() {
+  return mediator.promise(workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.SYNC_COMPLETE));
+}
+
+function ManagerWrapper(_manager) {
+  this.manager = _manager;
+  var self = this;
+
+  var methodNames = ['create', 'read', 'update', 'delete', 'list', 'start', 'stop', 'safeStop', 'forceSync', 'waitForSync'];
+  methodNames.forEach(function(methodName) {
+    self[methodName] = function() {
+      return q.when(self.manager[methodName].apply(self.manager, arguments));
+    };
+  });
+
+  self.checkStatus = function() {
+    return self.manager.checkStatus.apply(self.manager, arguments);
+  };
+
+  self.stepReview = function() {
+    return self.manager.stepReview.apply(self.manager, arguments);
+  };
+
+  self.nextStepIndex = function() {
+    return self.manager.nextStepIndex.apply(self.manager, arguments);
+  };
+}
+
+/**
+ *
+ * @param steps
+ * @param result
+ * @returns {{nextStepIndex: number, complete: *}}
+ */
+function stepReview(steps, result) {
+  var stepIndex = -1;
+  var complete;
+  if (result && result.stepResults && result.stepResults.length !== 0) {
+    complete = true;
+    for (var i=0; i < steps.length; i++) {
+      var step = steps[i];
+      var stepResult = result.stepResults[step.code];
+      if (stepResult && (stepResult.status === 'complete' || stepResult.status === 'pending')) {
+        stepIndex = i;
+        if (stepResult.status === 'pending') {
+          complete = false;
+        }
+      } else {
+        break;
+      }
+    }
+  }
+  return {
+    nextStepIndex: stepIndex,
+    complete: complete // false is any steps are "pending"
+  };
+}
+
+function nextStepIndex(steps, result) {
+  return this.stepReview(steps, result).nextStepIndex;
+}
+
+/**
+ *
+ * Checking the status of a workorder
+ *
+ * TODO: Constants
+ *
+ * @param {object} workorder  - The workorder to check status
+ * @param {object} workflow   - The workflow to check status
+ * @param {object} result     - The result to check status
+ * @returns {*}
+ */
+function checkStatus(workorder, workflow, result) {
+  var status;
+  var stepReview = this.stepReview(workflow.steps, result);
+  if (stepReview.nextStepIndex >= workflow.steps.length - 1 && stepReview.complete) {
+    status = 'Complete';
+  } else if (!workflow.assignee) {
+    status = 'Unassigned';
+  } else if (stepReview.nextStepIndex < 0) {
+    status = 'New';
+  } else {
+    status = 'In Progress';
+  }
+  return status;
+}
+
+
+/**
+ *
+ * Initialising the workflow-client with a mediator.
+ *
+ * @param _mediator
+ * @returns {ManagerWrapper|*}
+ */
+module.exports = function(_mediator) {
+
+  //If there is already a manager, use this
+  if (manager) {
+    return manager;
+  }
+
+  mediator = _mediator;
+
+  workflowSyncSubscribers = new MediatorTopicUtility(mediator);
+  workflowSyncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(config.datasetId);
+
+  manager = new ManagerWrapper({
+    create: create,
+    update: update,
+    list: list,
+    delete: remove,
+    start: start,
+    stop: stop,
+    read: read,
+    safeStop: safeStop,
+    forceSync: forceSync,
+    publishRecordDeltaReceived: _.noop,
+    waitForSync: waitForSync,
+    datasetId: config.datasetId,
+    stepReview: stepReview,
+    nextStepIndex: nextStepIndex,
+    checkStatus: checkStatus
+  });
+
+  return manager;
+};

--- a/lib/client/workflow-client/index.js
+++ b/lib/client/workflow-client/index.js
@@ -199,8 +199,11 @@ function ManagerWrapper(_manager) {
 
 /**
  *
- * @param steps
- * @param result
+ * This function checkes each of the result steps to determine if the workflow is complete,
+ * and if not, what is the next step in the workflow to display to the user.
+ *
+ * @param {object} steps
+ * @param {object} result
  * @returns {{nextStepIndex: number, complete: *}}
  */
 function stepReview(steps, result) {
@@ -211,9 +214,9 @@ function stepReview(steps, result) {
     for (var i=0; i < steps.length; i++) {
       var step = steps[i];
       var stepResult = result.stepResults[step.code];
-      if (stepResult && (stepResult.status === 'complete' || stepResult.status === 'pending')) {
+      if (stepResult && (stepResult.status === CONSTANTS.STATUS.COMPLETE || stepResult.status === CONSTANTS.STATUS.PENDING)) {
         stepIndex = i;
-        if (stepResult.status === 'pending') {
+        if (stepResult.status === CONSTANTS.STATUS.PENDING) {
           complete = false;
         }
       } else {
@@ -235,8 +238,6 @@ function nextStepIndex(steps, result) {
  *
  * Checking the status of a workorder
  *
- * TODO: Constants
- *
  * @param {object} workorder  - The workorder to check status
  * @param {object} workflow   - The workflow to check status
  * @param {object} result     - The result to check status
@@ -246,13 +247,13 @@ function checkStatus(workorder, workflow, result) {
   var status;
   var stepReview = this.stepReview(workflow.steps, result);
   if (stepReview.nextStepIndex >= workflow.steps.length - 1 && stepReview.complete) {
-    status = 'Complete';
+    status = CONSTANTS.STATUS.COMPLETE_DISPLAY;
   } else if (!workflow.assignee) {
-    status = 'Unassigned';
+    status = CONSTANTS.STATUS.UNASSIGNED_DISPLAY;
   } else if (stepReview.nextStepIndex < 0) {
-    status = 'New';
+    status = CONSTANTS.STATUS.NEW_DISPLAY;
   } else {
-    status = 'In Progress';
+    status = CONSTANTS.STATUS.PENDING_DISPLAY;
   }
   return status;
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,19 @@
+module.exports = {
+  TOPIC_PREFIX: "wfm",
+  WORKFLOW_ENTITY_NAME: "workflows",
+  SYNC_TOPIC_PREFIX: "wfm:sync",
+  TOPIC_SEPARATOR: ":",
+  ERROR_PREFIX: "error",
+  DONE_PREFIX: "done",
+  TOPICS: {
+    CREATE: "create",
+    UPDATE: "update",
+    LIST: "list",
+    REMOVE: "remove",
+    READ: "read",
+    START: "start",
+    STOP: "stop",
+    FORCE_SYNC: "force_sync",
+    SYNC_COMPLETE: "sync_complete"
+  }
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,14 @@ module.exports = {
   TOPIC_SEPARATOR: ":",
   ERROR_PREFIX: "error",
   DONE_PREFIX: "done",
+  STATUS: {
+    COMPLETE: "complete",
+    COMPLETE_DISPLAY: "Complete",
+    PENDING: "pending",
+    PENDING_DISPLAY: "In Progress",
+    NEW_DISPLAY: "New",
+    UNASSIGNED_DISPLAY: "Unassigned"
+  },
   TOPICS: {
     CREATE: "create",
     UPDATE: "update",

--- a/lib/server-spec.js
+++ b/lib/server-spec.js
@@ -1,13 +1,8 @@
-var sinon = require('sinon');
-var proxyquire = require('proxyquire');
 var express = require('express');
 var chai = require('chai');
 var expect = chai.expect;
 var app = express();
 var mockMbaasApi = {};
-var mockSync = {
-  init: sinon.spy()
-};
 var mediator = require('fh-wfm-mediator/lib/mediator.js');
 
 var CLOUD_TOPICS = {
@@ -30,9 +25,7 @@ var DONE = 'done:';
  * Set of unit tests for the sync topic subscribers
  */
 describe('Workflow Sync', function() {
-  var workflowServer = proxyquire('./server.js', {
-    'fh-wfm-sync/lib/server': mockSync
-  });
+  var workflowServer = require('./server.js');
 
   //Create
   it('should publish to done create cloud topic when the request to create a workflow has been completed', function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var sync = require('fh-wfm-sync/lib/server');
 var config = require('./config');
 var shortid = require('shortid');
 
 var WorflowTopics = require('fh-wfm-mediator/lib/topics');
 
-module.exports = function(mediator, app, mbaasApi) {
+module.exports = function(mediator) {
   //Used for cloud data storage topics
   var workflowCloudDataTopics = new WorflowTopics(mediator);
   workflowCloudDataTopics.prefix(config.cloudDataTopicPrefix).entity(config.datasetId);
@@ -14,8 +13,6 @@ module.exports = function(mediator, app, mbaasApi) {
   //Used for cloud topics
   var workflowCloudTopics = new WorflowTopics(mediator);
   workflowCloudTopics.prefix(config.cloudTopicPrefix).entity(config.datasetId);
-
-  sync.init(mediator, mbaasApi, config.datasetId, config.syncOptions);
 
   /**
    * Subscribers to sync topics which publishes to a data storage topic, subscribed to by a storage module,
@@ -31,8 +28,9 @@ module.exports = function(mediator, app, mbaasApi) {
       });
   });
 
-  workflowCloudTopics.on('list', function() {
-    return workflowCloudDataTopics.request('list');
+  workflowCloudTopics.on('list', function(listOptions) {
+    listOptions = listOptions || {};
+    return workflowCloudDataTopics.request('list', listOptions.filter, {uid: null});
   });
 
   workflowCloudTopics.on('update', function(workflowToUpdate) {

--- a/package.json
+++ b/package.json
@@ -20,20 +20,23 @@
   "license": "MIT",
   "dependencies": {
     "express": "4.14.0",
-    "fh-wfm-mediator": "0.1.0",
-    "fh-wfm-sync": "0.0.16",
     "lodash": "4.7.0",
     "ng-feedhenry": "0.3.0",
-    "shortid": "^2.2.6"
+    "shortid": "^2.2.6",
+    "string-template": "^1.0.0",
+    "q": "1.4.1",
+    "fh-wfm-mediator": "0.2.0-0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
     "grunt-eslint": "^18.0.0",
-    "grunt-mocha-test": "^0.13.2",
-    "proxyquire": "^1.7.10",
-    "sinon": "^1.17.7",
-    "sinon-as-promised": "^4.0.2"
+    "grunt-mocha-test": "0.13.2",
+    "load-grunt-tasks": "3.5.2",
+    "mocha": "3.2.0",
+    "sinon": "1.17.6",
+    "sinon-as-promised": "4.0.2",
+    "chai": "^3.5.0",
+    "proxyquire": "^1.7.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow",
-  "version": "0.0.27",
+  "version": "0.1.0-alpha.1",
   "description": "A workflow module for WFM",
   "main": "lib/angular/workflow-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation

The fh-wfm-sync direct dependency has been removed from this module.

Any interaction with the fh-wfm-sync module (or any other sync module) will now be done through the mediator pattern.

# Changes

- Added new CRUDL topics for results
- Removed fh-wfm-sync from the dependencies of the module.
- Switched the client to use mediator topics instead of the syncClient from fh-wfm-sync.