### PR TITLE
Updated workflowSync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ These workflowSync API methods all return Promises:
 | `workflowSync.manager.create(workflow)` | create a workflow |
 | `workflowSync.manager.read(workflowId)` | read a workflow |
 | `workflowSync.manager.update(workflow)` | update a workflow |
+| `workflowSync.manager.checkStatus(workorder, workflow, result)` | returns the current status of the workflow |
+| `workflowSync.manager.nextStepIndex(steps, result)` | returns the next step index of the workflow |
+| `workflowSync.manager.stepReview(steps, result)` | returns step review of the workflow |
+
 
 #### workflow directives
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These workflowSync API methods all return Promises:
 
 | Name | Attributes |
 | ---- | ----------- |
-| workflow-progress | stepIndex, workflow |
+| workflow-progress | stepIndex, workflow, overview |
 | workflow-step | step, workflow |
 | workflow-result | workflow, result |
 | workflow-form | value |

--- a/dist/workflow-progress.tpl.html.js
+++ b/dist/workflow-progress.tpl.html.js
@@ -16,13 +16,13 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '<div class="scroll-box">\n' +
     '  <ol>\n' +
-    '    <li ng-class="{active: \'-1\' == ctrl.stepIndex, complete: -1 < ctrl.stepIndex}">\n' +
+    '    <li ng-class="{active: \'-1\' == ctrl.stepIndex || ctrl.overview, complete: (-1 < ctrl.stepIndex && !ctrl.overview)}">\n' +
     '      <span class="md-caption"><md-icon md-font-set="material-icons">visibility</md-icon></span>Overview\n' +
     '    </li>\n' +
-    '    <li ng-repeat="step in ctrl.steps" ng-class="{active: $index == ctrl.stepIndex, complete: $index < ctrl.stepIndex}">\n' +
+    '    <li ng-repeat="step in ctrl.steps" ng-class="{active: $index == ctrl.stepIndex && !ctrl.overview, complete: $index < ctrl.stepIndex}">\n' +
     '      <span class="md-caption">{{$index + 1}}</span>{{step.name}}\n' +
     '    </li>\n' +
-    '    <li ng-class="{active: ctrl.steps.length <= ctrl.stepIndex, complete: ctrl.steps.length <= ctrl.stepIndex}">\n' +
+    '    <li ng-class="{active: ctrl.steps.length <= ctrl.stepIndex && !ctrl.overview, complete: ctrl.steps.length <= ctrl.stepIndex}">\n' +
     '      <span class="md-caption"><md-icon md-font-set="material-icons">done</md-icon></span>Summary\n' +
     '    </li>\n' +
     '  </ol>\n' +

--- a/lib/angular/directive.js
+++ b/lib/angular/directive.js
@@ -29,7 +29,8 @@ ngModule.directive('workflowProgress', function($templateCache, $timeout) {
   , template: $templateCache.get('wfm-template/workflow-progress.tpl.html')
   , scope: {
     stepIndex: '=',
-    workflow: '='
+    workflow: '=',
+    overview: '='
   }
   , link: function(scope, element) {
     $timeout(function() {
@@ -40,6 +41,7 @@ ngModule.directive('workflowProgress', function($templateCache, $timeout) {
     var self = this;
     self.workflow = $scope.workflow;
     self.steps = $scope.workflow.steps;
+    self.overview = $scope.overview;
     self.open = function() {
       self.closed = false;
     };

--- a/lib/angular/template/workflow-progress.tpl.html
+++ b/lib/angular/template/workflow-progress.tpl.html
@@ -7,13 +7,13 @@
 
 <div class="scroll-box">
   <ol>
-    <li ng-class="{active: '-1' == ctrl.stepIndex, complete: -1 < ctrl.stepIndex}">
+    <li ng-class="{active: \'-1\' == ctrl.stepIndex || ctrl.overview, complete: (-1 < ctrl.stepIndex && !ctrl.overview)}">
       <span class="md-caption"><md-icon md-font-set="material-icons">visibility</md-icon></span>Overview
     </li>
-    <li ng-repeat="step in ctrl.steps" ng-class="{active: $index == ctrl.stepIndex, complete: $index < ctrl.stepIndex}">
+    <li ng-repeat="step in ctrl.steps" ng-class="{active: $index == ctrl.stepIndex && !ctrl.overview, complete: $index < ctrl.stepIndex}">
       <span class="md-caption">{{$index + 1}}</span>{{step.name}}
     </li>
-    <li ng-class="{active: ctrl.steps.length <= ctrl.stepIndex, complete: ctrl.steps.length <= ctrl.stepIndex}">
+    <li ng-class="{active: ctrl.steps.length <= ctrl.stepIndex && !ctrl.overview, complete: ctrl.steps.length <= ctrl.stepIndex}">
       <span class="md-caption"><md-icon md-font-set="material-icons">done</md-icon></span>Summary
     </li>
   </ol>


### PR DESCRIPTION
There were several methods available missing on the doc:

Fixed a bug on workflow begin:
When a task is in progress, workflow begin progress appears like no step has been done, due to this directive on mobile:
`<workflow-progress workflow="ctrl.workflow" step-index="-1"></workflow-progress>`

Now I added a overview tag:
`<workflow-progress workflow="ctrl.workflow" step-index="ctrl.stepIndex+1" overview="true"></workflow-progress>`
And If one step is done it appears on green color icon.