### PR TITLE
Unassigning the subscribers when tearing down

### DIFF
--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -40,6 +40,7 @@ module.exports = {
   tearDown: function() {
     if (workflowSubscribers) {
       workflowSubscribers.unsubscribeAll();
+      workflowSubscribers = null;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A workflow module for WFM",
   "main": "lib/angular/workflow-ng.js",
   "repository": {


### PR DESCRIPTION
Fixed a bug where the subscribers were unassigned but it was never re-created