### PR TITLE
removes getErrorAndDoneTopicPromises() from workflow & calls from mediator instead

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
         options: {
           reporter: 'Spec',
           logErrors: true,
-          timeout: 1000,
+          timeout: 1500,
           run: true
         }
       }

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -17,17 +17,29 @@ module.exports = function listWorkflowSubscriber(workflowEntityTopics, workflowC
    * @returns {*}
    */
   return function handleListWorkflowsTopic(parameters) {
-    var self = this;
+    //var self = this;
     parameters = parameters || {};
-    var workflowListErrorTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+    //handleInMediator(CONSTANTS.TOPICS.LIST, workflowClient.list, parameters);
+    workflowEntityTopics.handleInmediator(CONSTANTS.TOPICS.LIST, workflowClient.list, parameters);
+  };
 
-    var workflowListDoneTopic = workflowEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+  /*// TODO move to mediator
+  function handleInMediator(topicName, clientMethod, parameters){
+    var workflowListErrorTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+    var workflowListDoneTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 
-    workflowClient.list()
-    .then(function(arrayOfWorkflows) {
-      self.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
-    }).catch(function(error) {
+    clientMethod(parameters)
+        .then(function(arrayOfWorkflows) {
+          self.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
+        }).catch(function(error) {
       self.mediator.publish(workflowListErrorTopic, error);
     });
-  };
+  }*/
+
 };
+
+
+
+
+
+

--- a/lib/client/workflow-client/workflowClient.js
+++ b/lib/client/workflow-client/workflowClient.js
@@ -43,12 +43,6 @@ function WorkflowMediatorService(mediator, config) {
  */
 WorkflowMediatorService.prototype.listResults = function listResults() {
   return this.resultsTopics.execute(CONSTANTS.TOPICS.LIST, this.config);
-
-  /*var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;*/
 };
 
 /**
@@ -63,16 +57,6 @@ WorkflowMediatorService.prototype.createResult = function createResult(resultToC
     topicUid: shortid.generate()
   };
   return this.resultsTopics.execute(CONSTANTS.TOPICS.CREATE, this.config, payload);
-
-  /*var topicUid = shortid.generate();
-  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.CREATE, topicUid);
-
-  this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.CREATE), {
-    resultToCreate: resultToCreate,
-    topicUid: topicUid
-  });
-
-  return promise;*/
 };
 
 /**
@@ -86,17 +70,7 @@ WorkflowMediatorService.prototype.updateResult = function updateResult(resultToU
     resultToUpdate: resultToUpdate,
     topicUid: shortid.generate()
   };
-  return this.resultsTopics.getErrorAndDoneTopicPromises(CONSTANTS.TOPICS.UPDATE, this.config, payload);
-
-  /*var topicUid = shortid.generate();
-  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.UPDATE, topicUid);
-
-  this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.UPDATE), {
-    resultToUpdate: resultToUpdate,
-    topicUid: topicUid
-  });
-
-  return promise;*/
+  return this.resultsTopics.execute(CONSTANTS.TOPICS.UPDATE, this.config, payload);
 };
 
 /**
@@ -210,12 +184,6 @@ WorkflowMediatorService.prototype.createNewResult = function createNewResult(wor
  */
 WorkflowMediatorService.prototype.list = function listWorkflows() {
   return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.LIST, this.config);
-
-  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;*/
 };
 
 /**
@@ -226,13 +194,6 @@ WorkflowMediatorService.prototype.list = function listWorkflows() {
  */
 WorkflowMediatorService.prototype.listWorkorders = function listWorkorders() {
   return this.workordersTopics.execute(CONSTANTS.TOPICS.LIST, this.config);
-
-  /*//var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
-  var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;*/
 };
 
 /**
@@ -248,15 +209,6 @@ WorkflowMediatorService.prototype.readWorkorder = function readWorkorder(workord
     topicUid: workorderId
   };
   return this.workordersTopics.execute(CONSTANTS.TOPICS.READ, this.config, payload);
-
-  /*var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.READ), {
-    id: workorderId,
-    topicUid: workorderId
-  });
-
-  return promise;*/
 };
 
 /**
@@ -272,12 +224,6 @@ WorkflowMediatorService.prototype.read = function readWorkflow(workflowId) {
     topicUid: workflowId
   };
   return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.READ, this.config, payload);
-
-  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.READ, workflowId);
-
-  this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: workflowId, topicUid: workflowId});
-
-  return promise;*/
 };
 
 /**
@@ -294,16 +240,6 @@ WorkflowMediatorService.prototype.update = function updateWorkflow(workflowToUpd
     topicUid: workflowToUpdate.id
   };
   return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.UPDATE, this.config, payload);
-
-
-  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.UPDATE, workflowToUpdate.id);
-
-  this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), {
-    itemToUpdate: workflowToUpdate,
-    topicUid: workflowToUpdate.id
-  });
-
-  return promise;*/
 };
 
 
@@ -320,16 +256,6 @@ WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCre
     topicUid: shortid.generate()
   };
   return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.CREATE, this.config, payload);
-
-  /*var topicUid = shortid.generate();
-  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.CREATE, topicUid);
-
-  this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), {
-    itemToCreate: workflowToCreate,
-    topicUid: topicUid
-  });
-
-  return promise;*/
 };
 
 /**
@@ -346,15 +272,6 @@ WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRe
     topicUid: workflowToRemove.id
   };
   return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.REMOVE, this.config, payload);
-
-  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.REMOVE, workflowToRemove.id);
-
-  this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE), {
-    id: workflowToRemove.id,
-    topicUid: workflowToRemove.id
-  });
-
-  return promise;*/
 };
 
 
@@ -365,13 +282,7 @@ WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRe
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.readUserProfile = function readUserProfile() {
-  return this.usersTopics.getErrorAndDoneTopicPromises(CONSTANTS.TOPICS.READ_PROFILE, this.config);
-
-  /*var promise = this.usersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.usersTopics, CONSTANTS.TOPICS.READ_PROFILE);
-
-  this.mediator.publish(this.usersTopics.getTopic(CONSTANTS.TOPICS.READ_PROFILE));
-
-  return promise;*/
+  return this.usersTopics.execute(CONSTANTS.TOPICS.READ_PROFILE, this.config);
 };
 
 module.exports = WorkflowMediatorService;

--- a/lib/client/workflow-client/workflowClient.js
+++ b/lib/client/workflow-client/workflowClient.js
@@ -4,11 +4,6 @@ var shortid = require('shortid');
 var CONSTANTS = require('../../constants');
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 
-var topicDefaults = {
-  "DONE_PREFIX": CONSTANTS.DONE_PREFIX,
-  "ERROR_PREFIX": CONSTANTS.ERROR_PREFIX,
-  "TOPIC_TIMEOUT": CONSTANTS.TOPIC_TIMEOUT
-};
 
 /**
  *
@@ -47,11 +42,13 @@ function WorkflowMediatorService(mediator, config) {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.listResults = function listResults() {
-  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.LIST);
+  return this.resultsTopics.execute(CONSTANTS.TOPICS.LIST, this.config);
+
+  /*var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.LIST));
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -61,7 +58,13 @@ WorkflowMediatorService.prototype.listResults = function listResults() {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.createResult = function createResult(resultToCreate) {
-  var topicUid = shortid.generate();
+  var payload = {
+    resultToCreate: resultToCreate,
+    topicUid: shortid.generate()
+  };
+  return this.resultsTopics.execute(CONSTANTS.TOPICS.CREATE, this.config, payload);
+
+  /*var topicUid = shortid.generate();
   var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.CREATE, topicUid);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.CREATE), {
@@ -69,7 +72,7 @@ WorkflowMediatorService.prototype.createResult = function createResult(resultToC
     topicUid: topicUid
   });
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -79,7 +82,13 @@ WorkflowMediatorService.prototype.createResult = function createResult(resultToC
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.updateResult = function updateResult(resultToUpdate) {
-  var topicUid = shortid.generate();
+  var payload = {
+    resultToUpdate: resultToUpdate,
+    topicUid: shortid.generate()
+  };
+  return this.resultsTopics.getErrorAndDoneTopicPromises(CONSTANTS.TOPICS.UPDATE, this.config, payload);
+
+  /*var topicUid = shortid.generate();
   var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.UPDATE, topicUid);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.UPDATE), {
@@ -87,7 +96,7 @@ WorkflowMediatorService.prototype.updateResult = function updateResult(resultToU
     topicUid: topicUid
   });
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -200,11 +209,13 @@ WorkflowMediatorService.prototype.createNewResult = function createNewResult(wor
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.list = function listWorkflows() {
-  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.LIST);
+  return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.LIST, this.config);
+
+  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -214,12 +225,14 @@ WorkflowMediatorService.prototype.list = function listWorkflows() {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.listWorkorders = function listWorkorders() {
-  //var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
+  return this.workordersTopics.execute(CONSTANTS.TOPICS.LIST, this.config);
+
+  /*//var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
   var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.LIST));
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -230,14 +243,20 @@ WorkflowMediatorService.prototype.listWorkorders = function listWorkorders() {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.readWorkorder = function readWorkorder(workorderId) {
-  var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
+  var payload = {
+    id: workorderId,
+    topicUid: workorderId
+  };
+  return this.workordersTopics.execute(CONSTANTS.TOPICS.READ, this.config, payload);
+
+  /*var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
 
   this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.READ), {
     id: workorderId,
     topicUid: workorderId
   });
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -248,11 +267,17 @@ WorkflowMediatorService.prototype.readWorkorder = function readWorkorder(workord
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.read = function readWorkflow(workflowId) {
-  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.READ, workflowId);
+  var payload = {
+    id: workflowId,
+    topicUid: workflowId
+  };
+  return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.READ, this.config, payload);
+
+  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.READ, workflowId);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: workflowId, topicUid: workflowId});
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -264,14 +289,21 @@ WorkflowMediatorService.prototype.read = function readWorkflow(workflowId) {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.update = function updateWorkflow(workflowToUpdate) {
-  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.UPDATE, workflowToUpdate.id);
+  var payload = {
+    itemToUpdate: workflowToUpdate,
+    topicUid: workflowToUpdate.id
+  };
+  return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.UPDATE, this.config, payload);
+
+
+  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.UPDATE, workflowToUpdate.id);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), {
     itemToUpdate: workflowToUpdate,
     topicUid: workflowToUpdate.id
   });
 
-  return promise;
+  return promise;*/
 };
 
 
@@ -283,7 +315,13 @@ WorkflowMediatorService.prototype.update = function updateWorkflow(workflowToUpd
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCreate) {
-  var topicUid = shortid.generate();
+  var payload = {
+    itemToCreate: workflowToCreate,
+    topicUid: shortid.generate()
+  };
+  return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.CREATE, this.config, payload);
+
+  /*var topicUid = shortid.generate();
   var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.CREATE, topicUid);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), {
@@ -291,7 +329,7 @@ WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCre
     topicUid: topicUid
   });
 
-  return promise;
+  return promise;*/
 };
 
 /**
@@ -303,15 +341,20 @@ WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCre
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRemove) {
+  var payload = {
+    id: workflowToRemove.id,
+    topicUid: workflowToRemove.id
+  };
+  return this.workflowSyncSubscribers.execute(CONSTANTS.TOPICS.REMOVE, this.config, payload);
 
-  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.REMOVE, workflowToRemove.id);
+  /*var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.REMOVE, workflowToRemove.id);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE), {
     id: workflowToRemove.id,
     topicUid: workflowToRemove.id
   });
 
-  return promise;
+  return promise;*/
 };
 
 
@@ -322,11 +365,13 @@ WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRe
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.readUserProfile = function readUserProfile() {
-  var promise = this.usersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.usersTopics, CONSTANTS.TOPICS.READ_PROFILE);
+  return this.usersTopics.getErrorAndDoneTopicPromises(CONSTANTS.TOPICS.READ_PROFILE, this.config);
+
+  /*var promise = this.usersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.usersTopics, CONSTANTS.TOPICS.READ_PROFILE);
 
   this.mediator.publish(this.usersTopics.getTopic(CONSTANTS.TOPICS.READ_PROFILE));
 
-  return promise;
+  return promise;*/
 };
 
 module.exports = WorkflowMediatorService;

--- a/lib/client/workflow-client/workflowClient.js
+++ b/lib/client/workflow-client/workflowClient.js
@@ -4,31 +4,11 @@ var shortid = require('shortid');
 var CONSTANTS = require('../../constants');
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 
-/**
- *
- * Getting Promises for done and error topics.
- * This will resolve or reject the returned promise depending on the topic published.
- *
- *
- * TODO: This may be of more use in fh-wfm-mediator...
- *
- * @param doneTopicPromise  - A promise for the done topic.
- * @param errorTopicPromise - A promise for the error topic.
- * @returns {Promise}
- */
-function getTopicPromises(doneTopicPromise, errorTopicPromise) {
-  var deferred = q.defer();
-
-  doneTopicPromise.then(function(createdWorkorder) {
-    deferred.resolve(createdWorkorder);
-  });
-
-  errorTopicPromise.then(function(error) {
-    deferred.reject(error);
-  });
-
-  return deferred.promise;
-}
+var topicDefaults = {
+  "DONE_PREFIX": CONSTANTS.DONE_PREFIX,
+  "ERROR_PREFIX": CONSTANTS.ERROR_PREFIX,
+  "TOPIC_TIMEOUT": CONSTANTS.TOPIC_TIMEOUT
+};
 
 /**
  *
@@ -60,35 +40,6 @@ function WorkflowMediatorService(mediator, config) {
     .entity(CONSTANTS.WORKFLOW_ENTITY_NAME);
 }
 
-
-/**
- *
- * Getting Promises for the done and error topics.
- *
- * TODO: This may be of more use in fh-wfm-mediator...
- *
- * @param {MediatorTopicUtility} topicGenerator
- * @param {string} topicName   - The name of the topic to generate
- * @param {string} [topicUid]  - A topic UID if required.
- * @returns {Promise} - A promise for the topic.
- */
-WorkflowMediatorService.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(topicGenerator, topicName, topicUid) {
-  var doneTopic = topicGenerator.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
-  var errorTopic = topicGenerator.getTopic(topicName, CONSTANTS.ERROR_PREFIX, topicUid);
-
-  var doneTopicPromise = topicGenerator.mediator.promise(doneTopic);
-  var errorTopicPromise = topicGenerator.mediator.promise(errorTopic);
-
-  var timeoutDefer = q.defer();
-
-  setTimeout(function() {
-    timeoutDefer.reject(new Error("Timeout For Topic: " + doneTopic));
-  }, this.config.topicTimeout || CONSTANTS.TOPIC_TIMEOUT);
-
-  //Either one of these promises resolves/rejects or it will time out.
-  return q.race([getTopicPromises(doneTopicPromise, errorTopicPromise), timeoutDefer.promise]);
-};
-
 /**
  *
  * Listing All Results
@@ -96,7 +47,7 @@ WorkflowMediatorService.prototype.getErrorAndDoneTopicPromises = function getErr
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.listResults = function listResults() {
-  var promise = this.getErrorAndDoneTopicPromises(this.resultsTopics, CONSTANTS.TOPICS.LIST);
+  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.LIST));
 
@@ -111,7 +62,7 @@ WorkflowMediatorService.prototype.listResults = function listResults() {
  */
 WorkflowMediatorService.prototype.createResult = function createResult(resultToCreate) {
   var topicUid = shortid.generate();
-  var promise = this.getErrorAndDoneTopicPromises(this.resultsTopics, CONSTANTS.TOPICS.CREATE, topicUid);
+  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.CREATE, topicUid);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.CREATE), {
     resultToCreate: resultToCreate,
@@ -129,7 +80,7 @@ WorkflowMediatorService.prototype.createResult = function createResult(resultToC
  */
 WorkflowMediatorService.prototype.updateResult = function updateResult(resultToUpdate) {
   var topicUid = shortid.generate();
-  var promise = this.getErrorAndDoneTopicPromises(this.resultsTopics, CONSTANTS.TOPICS.UPDATE, topicUid);
+  var promise = this.resultsTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.resultsTopics, CONSTANTS.TOPICS.UPDATE, topicUid);
 
   this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.UPDATE), {
     resultToUpdate: resultToUpdate,
@@ -249,7 +200,7 @@ WorkflowMediatorService.prototype.createNewResult = function createNewResult(wor
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.list = function listWorkflows() {
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowSyncSubscribers, CONSTANTS.TOPICS.LIST);
+  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
 
@@ -263,7 +214,8 @@ WorkflowMediatorService.prototype.list = function listWorkflows() {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.listWorkorders = function listWorkorders() {
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
+  //var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
+  var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.LIST);
 
   this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.LIST));
 
@@ -278,7 +230,7 @@ WorkflowMediatorService.prototype.listWorkorders = function listWorkorders() {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.readWorkorder = function readWorkorder(workorderId) {
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
+  var promise = this.workordersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
 
   this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.READ), {
     id: workorderId,
@@ -296,7 +248,7 @@ WorkflowMediatorService.prototype.readWorkorder = function readWorkorder(workord
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.read = function readWorkflow(workflowId) {
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowSyncSubscribers, CONSTANTS.TOPICS.READ, workflowId);
+  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.READ, workflowId);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: workflowId, topicUid: workflowId});
 
@@ -312,7 +264,7 @@ WorkflowMediatorService.prototype.read = function readWorkflow(workflowId) {
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.update = function updateWorkflow(workflowToUpdate) {
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowSyncSubscribers, CONSTANTS.TOPICS.UPDATE, workflowToUpdate.id);
+  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.UPDATE, workflowToUpdate.id);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), {
     itemToUpdate: workflowToUpdate,
@@ -332,7 +284,7 @@ WorkflowMediatorService.prototype.update = function updateWorkflow(workflowToUpd
  */
 WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCreate) {
   var topicUid = shortid.generate();
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowSyncSubscribers, CONSTANTS.TOPICS.CREATE, topicUid);
+  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.CREATE, topicUid);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), {
     itemToCreate: workflowToCreate,
@@ -352,7 +304,7 @@ WorkflowMediatorService.prototype.create = function createWorkflow(workflowToCre
  */
 WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRemove) {
 
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowSyncSubscribers, CONSTANTS.TOPICS.REMOVE, workflowToRemove.id);
+  var promise = this.workflowSyncSubscribers.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.workflowSyncSubscribers, CONSTANTS.TOPICS.REMOVE, workflowToRemove.id);
 
   this.mediator.publish(this.workflowSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE), {
     id: workflowToRemove.id,
@@ -370,7 +322,7 @@ WorkflowMediatorService.prototype.remove = function removeWorkorder(workflowToRe
  * @returns {Promise}
  */
 WorkflowMediatorService.prototype.readUserProfile = function readUserProfile() {
-  var promise = this.getErrorAndDoneTopicPromises(this.usersTopics, CONSTANTS.TOPICS.READ_PROFILE);
+  var promise = this.usersTopics.getErrorAndDoneTopicPromises(this.config, topicDefaults, this.usersTopics, CONSTANTS.TOPICS.READ_PROFILE);
 
   this.mediator.publish(this.usersTopics.getTopic(CONSTANTS.TOPICS.READ_PROFILE));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A workflow module for WFM",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "ng-feedhenry": "0.3.0",
     "q": "1.4.1",
     "shortid": "^2.2.6",
-    "fh-wfm-mediator": "0.3.1"
+    "fh-wfm-mediator": "0.4.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
moves getErrorAndDoneTopicPromises() out of module & calls them from mediator instead

part of https://issues.jboss.org/browse/RAINCATCH-629 which involved refactoring raincatcher-workorder and raincatcher-workflow to remove the getTopicPromises() and getErrorAndDoneTopicPromises() functionality in them, and move them into the mediator instead

related prs: 
https://github.com/feedhenry-raincatcher/raincatcher-workorder/pull/23
https://github.com/feedhenry-raincatcher/raincatcher-mediator/pull/23