### PR TITLE
Added filtering unique identifiers to separate lists with different filters

### DIFF
--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -29,8 +29,16 @@ module.exports = function(mediator) {
   });
 
   workflowCloudTopics.on('list', function(listOptions) {
+    var self = this;
     listOptions = listOptions || {};
-    return workflowCloudDataTopics.request('list', listOptions.filter, {uid: null});
+    listOptions.filter = listOptions.filter || {};
+    listOptions.filter.topicUid = listOptions.topicUid || shortid.generate();
+
+    workflowCloudDataTopics.request('list', listOptions.filter, {uid: listOptions.filter.topicUid}).then(function(list) {
+      self.mediator.publish(workflowCloudTopics.getTopic('list', 'done', listOptions.topicUid), list);
+    }).catch(function(err) {
+      self.mediator.publish(workflowCloudTopics.getTopic('list', 'error', listOptions.topicUid), err);
+    });
   });
 
   workflowCloudTopics.on('update', function(workflowToUpdate) {

--- a/lib/cloud/server-spec.js
+++ b/lib/cloud/server-spec.js
@@ -63,9 +63,9 @@ describe('Workflow Sync', function() {
     workflowServer(mediator, app, mockMbaasApi);
 
     //Mock of the data topic subscriber in the storage module
-    mediator.subscribe(CLOUD_DATA_TOPICS.list, function() {
+    mediator.subscribe(CLOUD_DATA_TOPICS.list, function(filter) {
       //Publish to done list data topic to fake getting the list of workflows by storage module
-      mediator.publish(DONE + CLOUD_DATA_TOPICS.list, mockWorkflowArray);
+      mediator.publish(DONE + CLOUD_DATA_TOPICS.list + ":" + filter.topicUid, mockWorkflowArray);
     });
 
     return mediator.request(CLOUD_TOPICS.list).then(function(listWorkflow) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A workflow module for WFM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

List topics can contain different filters based on parameters passed from sync. In order to ensure that the `done` topics are related to the correct filter, we need to include a topic unique identifier.