### PR TITLE
Assign new status to workflows

### DIFF
--- a/lib/client/mediator-subscribers/begin-spec.js
+++ b/lib/client/mediator-subscribers/begin-spec.js
@@ -41,7 +41,7 @@ describe("Beginning A Workflow For A Single Workorder", function() {
   var mockResult = fixtures.mockResult();
 
   var newResult = {
-    status: "New",
+    status: "In Progress",
     nextStepIndex: 0,
     workorderId: mockWorkorder.id,
     stepResults: {}

--- a/lib/client/workflow-client/workflowClient-spec.js
+++ b/lib/client/workflow-client/workflowClient-spec.js
@@ -4,6 +4,7 @@ var expect = chai.expect;
 require('sinon-as-promised');
 var _ = require('lodash');
 var WorkflowClient = require('./workflowClient');
+var CONSTANTS = require('../../constants');
 
 describe("Workflow Mediator Client", function() {
 
@@ -33,6 +34,12 @@ describe("Workflow Mediator Client", function() {
         view: "<mockview3template></mockview3template>"
       }
     }]
+  };
+
+  var mockWorkorder = {
+    id: "mockworkorderid",
+    workflowId: "mockworkflowid",
+    assignee: "userid"
   };
 
   var mockResult = {
@@ -137,6 +144,12 @@ describe("Workflow Mediator Client", function() {
         nextStepIndex: 3,
         complete: true
       });
+    });
+
+    it("should return new if there is no result for a workflow", function() {
+      var status = workflowClient.checkStatus(mockWorkorder, mockWorkflow);
+
+      expect(status).to.equal(CONSTANTS.STATUS.NEW_DISPLAY);
     });
 
   });

--- a/lib/client/workflow-client/workflowClient.js
+++ b/lib/client/workflow-client/workflowClient.js
@@ -155,7 +155,7 @@ WorkflowMediatorService.prototype.checkStatus = function checkStatus(workorder, 
     status = CONSTANTS.STATUS.COMPLETE_DISPLAY;
   } else if (!workorder.assignee) {
     status = CONSTANTS.STATUS.UNASSIGNED_DISPLAY;
-  } else if (stepReview.nextStepIndex < 0) {
+  } else if (!result) {
     status = CONSTANTS.STATUS.NEW_DISPLAY;
   } else {
     status = CONSTANTS.STATUS.PENDING_DISPLAY;

--- a/lib/client/workflow-client/workflowClient.js
+++ b/lib/client/workflow-client/workflowClient.js
@@ -239,7 +239,7 @@ WorkflowMediatorService.prototype.getResultByWorkorderId = function getResultByW
  * @param workorderId
  */
 WorkflowMediatorService.prototype.createNewResult = function createNewResult(workorderId) {
-  return this.createResult({status: CONSTANTS.STATUS.NEW_DISPLAY, nextStepIndex: 0, workorderId: workorderId, stepResults: {}});
+  return this.createResult({status: CONSTANTS.STATUS.PENDING_DISPLAY, nextStepIndex: 0, workorderId: workorderId, stepResults: {}});
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A workflow module for WFM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

Workorders with no associated result object should always be considered as "New".

Related to https://issues.jboss.org/browse/RAINCATCH-838